### PR TITLE
Fix Docker commands

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -23,18 +23,17 @@ RUN apt-get update && \
 RUN git config --system --add safe.directory '*' && \
     git config --global http.sslVerify false # This is a workaround and it should be changed
 
-RUN mkdir /src && \
-    cd /src && \
-    git clone https://code.qt.io/qt/qt5.git qt6 && \
-    cd qt6 && \
-    ./init-repository --module-subset="qtbase,qtgrpc,qtrepotools" -f
+# Clone the Qt dev branch
+RUN git clone -b dev --depth 1 https://code.qt.io/qt/qt5.git qtsrc && \
+    cd qtsrc && \
+    ./init-repository --module-subset="qtbase,qtgrpc,qtrepotools" -f --no-optional-deps
 
-RUN cd /src && \
-    mkdir qt6-build && \
-    cd qt6-build && \
-    ../qt6/configure -developer-build -nomake examples -make tools -make tests -widgets -gui -prefix /opt/qt6 && \
-    cmake --build . --parallel && \
-    cmake --build . --target install
+# Configure and build Qt
+RUN mkdir qtbuild && \
+	cd qtbuild && \
+	../qtsrc/configure -developer-build -nomake examples -nomake tests -no-opengl -skip qtdeclarative && \
+	ninja
+# Finished Qt build will not exist in directory '/qtbuild/qtbase'
 
 # The entry point or command to run when the container starts can be set here
 # For example, opening a bash shell or starting a specific development tool

--- a/extra-packages
+++ b/extra-packages
@@ -26,3 +26,16 @@ mesa-common-dev
 # Python for scripting within 3D Slicer
 python3-dev
 python3-pip
+
+# Packages specific to building Qt with GRPC module
+git
+cmake
+g++
+ninja-build
+pkg-config
+libprotoc-dev
+libprotobuf-dev
+protobuf-compiler 
+protobuf-compiler-grpc
+libgrpc-dev
+libgrpc++-dev


### PR DESCRIPTION
Note: To run the tests you can go into an interactive shell on this image and do the following:

```
git clone https://github.com/cecilianor/Qt-thesis.git
cd Qt-thesis
cmake . -B build -G Ninja -DCMAKE_PREFIX_PATH="/qtbuild/qtbase" -DBUILD_TESTS=ON
cd build
ninja
```
This completes the build-step on our project. To run the actual tests you can run the following inside the `build` folder:
```
export QT_QPA_PLATFORM=offscreen
ctest --rerun-failed --output-on-failure
```


You can then expect to get the following output:
```
root@f01ed4b1fc41:~/Qt-thesis/build# export QT_QPA_PLATFORM=offscreen
ctest --rerun-failed --output-on-failure
Test project /root/Qt-thesis/build
    Start 1: TileLoaderTest
1/5 Test #1: TileLoaderTest ...................   Passed    0.39 sec
    Start 2: RenderTest
2/5 Test #2: RenderTest .......................   Passed    0.01 sec
    Start 3: LayerStyleTest
3/5 Test #3: LayerStyleTest ...................   Passed    0.01 sec
    Start 4: VectorTileTest
4/5 Test #4: VectorTileTest ...................   Passed    0.31 sec
    Start 5: EvaluatorTest
5/5 Test #5: EvaluatorTest ....................   Passed    0.02 sec

100% tests passed, 0 tests failed out of 5

Total Test time (real) =   0.75 sec
```

Note: Most of these instructions should be in the report, but they're not entirely complete just yet.